### PR TITLE
[#18] Give lines provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "expr-parser"
 version = "0.1.0"
-source = "git+https://github.com/zyxw59/expr-parser#c034c47279dd28a370684f3ea947648461693013"
+source = "git+https://github.com/zyxw59/expr-parser#d2e5d8c8d56ecc331f4375df5bc99c6e6803e246"
 dependencies = [
  "bstr",
  "bytes",

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,14 +9,6 @@ pub enum Error {
     #[error("Math error on line {1}: {0}")]
     Math(#[source] MathError, usize),
     #[error(
-        "Point ({name}) redefined on line {line} (originally defined on line {original_line})"
-    )]
-    PointRedefinition {
-        name: Variable,
-        line: usize,
-        original_line: usize,
-    },
-    #[error(
         "Route ({name}) redefined on line {line} (originally defined on line {original_line})"
     )]
     RouteRedefinition {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -103,7 +103,6 @@ impl Evaluator {
                         let value = f64::try_from(&value).map_err(|err| Error::Math(err, line))?;
                         self.points.set_inner_radius(value);
                     }
-                    // TODO: handle redefinition of points
                 }
                 let mut slot = self.variables.entry(name.clone());
                 for field in fields {
@@ -125,7 +124,6 @@ impl Evaluator {
                 self.variables.insert(name, Value::Function(function));
             }
             StatementKind::PointSingle(name, expr) => {
-                // TODO: handle redefinition of points
                 // TODO: this is now completeley redundant with normal variable statements
                 let value =
                     evaluate_expression(self, expr).map_err(|err| Error::Math(err, line))?;

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -293,7 +293,7 @@ impl EvaluationContext for Evaluator {
 mod tests {
     use crate::{
         parser::parse,
-        values::{tests::value, Point, Value},
+        values::{Point, Value},
     };
 
     use super::{EvaluationContext, Evaluator};
@@ -339,7 +339,7 @@ mod tests {
         evaluator
             .evaluate_all(parse("point a = (1, 1);").unwrap())
             .unwrap();
-        assert_eq!(evaluator.get_variable("a"), Some(value!(1, 1)));
+        assert_eq!(evaluator.get_variable("a").unwrap(), Point(1.0, 1.0));
     }
 
     macro_rules! points_multiple {
@@ -352,19 +352,19 @@ mod tests {
             let (_, start_id) = evaluator.get_point(stringify!($first).into(), 0).unwrap();
             let (_, end_id) = evaluator.get_point(stringify!($last).into(), 0).unwrap();
             assert_eq!(
-                evaluator.points.get_points_of_line(start_id, end_id),
-                Some(vec![
+                evaluator.points.get_points_of_line(start_id, end_id).unwrap(),
+                [
                      Point($first_x as f64, $first_y as f64),
                      $(Point($x as f64, $y as f64)),*,
                      Point($last_x as f64, $last_y as f64)
-                ]),
+                ],
             );
             for (name, value) in [
-                 (stringify!($first), value!($first_x, $first_y)),
-                 $((stringify!($name), value!($x, $y))),*,
-                 (stringify!($last), value!($last_x, $last_y)),
+                 (stringify!($first), Point($first_x as f64, $first_y as f64)),
+                 $((stringify!($name), Point($x as f64, $y as f64))),*,
+                 (stringify!($last), Point($last_x as f64, $last_y as f64)),
             ] {
-                assert_eq!(evaluator.get_variable(name), Some(value));
+                assert_eq!(evaluator.get_variable(name).unwrap(), value);
             }
         }
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -21,10 +21,12 @@ pub trait EvaluationContext {
     fn get_variable(&self, name: &str) -> Option<Value>;
 
     fn get_fn_arg(&self, idx: usize) -> Option<Value>;
+
+    fn point_collection(&mut self) -> &mut PointCollection;
 }
 
 pub fn evaluate_expression(
-    ctx: &dyn EvaluationContext,
+    ctx: &mut dyn EvaluationContext,
     expr: impl IntoIterator<Item = ExpressionBit>,
 ) -> Result<Value, MathError> {
     EvaluatorTrait::evaluate(ctx, expr)
@@ -35,7 +37,7 @@ impl EvaluatorTrait<Position, BinaryOperator, UnaryOperator, Term> for dyn Evalu
     type Error = MathError;
 
     fn evaluate_binary_operator(
-        &self,
+        &mut self,
         _span: Span<Position>,
         operator: BinaryOperator,
         lhs: Value,
@@ -45,7 +47,7 @@ impl EvaluatorTrait<Position, BinaryOperator, UnaryOperator, Term> for dyn Evalu
     }
 
     fn evaluate_unary_operator(
-        &self,
+        &mut self,
         _span: Span<Position>,
         operator: UnaryOperator,
         argument: Value,
@@ -53,7 +55,7 @@ impl EvaluatorTrait<Position, BinaryOperator, UnaryOperator, Term> for dyn Evalu
         operator.call(argument, self)
     }
 
-    fn evaluate_term(&self, _span: Span<Position>, term: Term) -> Result<Value, MathError> {
+    fn evaluate_term(&mut self, _span: Span<Position>, term: Term) -> Result<Value, MathError> {
         match term {
             Term::Number(x) => Ok(Value::Number(x)),
             Term::String(s) => Ok(Value::String(Rc::new(s))),
@@ -297,15 +299,9 @@ impl EvaluationContext for Evaluator {
     fn get_fn_arg(&self, _idx: usize) -> Option<Value> {
         None
     }
-}
 
-impl EvaluationContext for () {
-    fn get_variable(&self, _name: &str) -> Option<Value> {
-        None
-    }
-
-    fn get_fn_arg(&self, _idx: usize) -> Option<Value> {
-        None
+    fn point_collection(&mut self) -> &mut PointCollection {
+        &mut self.points
     }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -124,9 +124,17 @@ impl Evaluator {
                 self.variables.insert(name, Value::Function(function));
             }
             StatementKind::PointSingle(name, expr) => {
-                // TODO: this is now completeley redundant with normal variable statements
-                let value =
-                    evaluate_expression(self, expr).map_err(|err| Error::Math(err, line))?;
+                // NOTE: this statement is almost identical to a normal variable assignment, except
+                // that it type-checks that the expression evaluates to a point.
+                let value = evaluate_expression(self, expr)
+                    .and_then(|value| {
+                        if !matches!(value, Value::Point(..)) {
+                            Err(MathError::Type(crate::error::Type::Point, value.into()))
+                        } else {
+                            Ok(value)
+                        }
+                    })
+                    .map_err(|err| Error::Math(err, line))?;
                 self.variables.insert(name, value);
             }
             StatementKind::PointSpaced {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -293,6 +293,7 @@ impl EvaluationContext for Evaluator {
 mod tests {
     use crate::{
         parser::parse,
+        points::{LineId, PointId},
         values::{Point, Value},
     };
 
@@ -340,6 +341,32 @@ mod tests {
             .evaluate_all(parse("point a = (1, 1);").unwrap())
             .unwrap();
         assert_eq!(evaluator.get_variable("a").unwrap(), Point(1.0, 1.0));
+    }
+
+    #[test]
+    fn grid() {
+        let mut evaluator = Evaluator::new();
+        let input = "
+N = dir 0;
+E = dir 90;
+
+n0 = (0 * N) >> E;
+e0 = (0 * E) >> N;
+e1 = (1 * E) >> N;
+e2 = (2 * E) >> N;
+
+point n0e0 = n0 & e0;
+point n0e1 = n0 & e1;
+point n0e2 = n0 & e2;
+";
+        evaluator.evaluate_all(parse(input).unwrap()).unwrap();
+        let (_, n0e0): (_, PointId) = evaluator.variables["n0e0"].clone().try_into().unwrap();
+        let (_, n0e1): (_, PointId) = evaluator.variables["n0e1"].clone().try_into().unwrap();
+        let (_, n0e2): (_, PointId) = evaluator.variables["n0e2"].clone().try_into().unwrap();
+        let (_, n0): (_, LineId) = evaluator.variables["n0"].clone().try_into().unwrap();
+        assert_eq!(evaluator.points.get_or_insert_line(n0e0, n0e1), n0);
+        assert_eq!(evaluator.points.get_or_insert_line(n0e0, n0e2), n0);
+        assert_eq!(evaluator.points.get_or_insert_line(n0e1, n0e2), n0);
     }
 
     macro_rules! points_multiple {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -300,7 +300,7 @@ mod tests {
     use crate::{
         parser::parse,
         points::{LineId, PointId},
-        values::{Point, Value},
+        values::Point,
     };
 
     use super::{EvaluationContext, Evaluator};
@@ -309,7 +309,7 @@ mod tests {
     fn variables_set() {
         let mut evaluator = Evaluator::new();
         evaluator.evaluate_all(parse("x = 1;").unwrap()).unwrap();
-        assert_eq!(evaluator.variables.get("x"), Some(&Value::Number(1.0)));
+        assert_eq!(*evaluator.variables.get("x").unwrap(), 1.0);
     }
 
     #[test]
@@ -318,8 +318,8 @@ mod tests {
         evaluator
             .evaluate_all(parse("x = 1; z = x * 2;").unwrap())
             .unwrap();
-        assert_eq!(evaluator.variables.get("x"), Some(&Value::Number(1.0)));
-        assert_eq!(evaluator.variables.get("z"), Some(&Value::Number(2.0)));
+        assert_eq!(*evaluator.variables.get("x").unwrap(), 1.0);
+        assert_eq!(*evaluator.variables.get("z").unwrap(), 2.0);
     }
 
     #[test]
@@ -328,7 +328,7 @@ mod tests {
         evaluator
             .evaluate_all(parse("fn f(x) = x + 1; y = f(3);").unwrap())
             .unwrap();
-        assert_eq!(evaluator.variables.get("y"), Some(&Value::Number(4.0)));
+        assert_eq!(*evaluator.variables.get("y").unwrap(), 4.0);
     }
 
     #[test]
@@ -337,7 +337,7 @@ mod tests {
         evaluator
             .evaluate_all(parse("fn f(x, y) = x * y; z = f(3, 2);").unwrap())
             .unwrap();
-        assert_eq!(evaluator.variables.get("z"), Some(&Value::Number(6.0)));
+        assert_eq!(*evaluator.variables.get("z").unwrap(), 6.0);
     }
 
     #[test]

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -8,6 +8,7 @@ use crate::{
     evaluator::{evaluate_expression, EvaluationContext},
     operators::{BinaryOperator, UnaryOperator},
     parser::Position,
+    points::PointCollection,
     values::{Result, Value},
 };
 
@@ -18,22 +19,22 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn apply(&self, args: &[Value], context: &dyn EvaluationContext) -> Result<Value> {
+    pub fn apply(&self, args: &[Value], context: &mut dyn EvaluationContext) -> Result<Value> {
         let expected = self.num_args;
         let actual = args.len();
         if expected != actual {
             return Err(MathError::Arguments { expected, actual });
         }
-        let locals = FunctionEvaluator {
+        let mut locals = FunctionEvaluator {
             parent: context,
             args,
         };
-        evaluate_expression(&locals, self.expression.iter().cloned())
+        evaluate_expression(&mut locals, self.expression.iter().cloned())
     }
 }
 
 pub struct FunctionEvaluator<'a> {
-    parent: &'a dyn EvaluationContext,
+    parent: &'a mut dyn EvaluationContext,
     args: &'a [Value],
 }
 
@@ -44,6 +45,10 @@ impl EvaluationContext for FunctionEvaluator<'_> {
 
     fn get_fn_arg(&self, idx: usize) -> Option<Value> {
         self.args.get(idx).cloned()
+    }
+
+    fn point_collection(&mut self) -> &mut PointCollection {
+        self.parent.point_collection()
     }
 }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -24,7 +24,7 @@ pub enum Precedence {
 
 macro_rules! as_binary_operator {
     ($fn:path) => {{
-        fn _f(a: Value, b: Value, _: &dyn EvaluationContext) -> Result {
+        fn _f(a: Value, b: Value, _: &mut dyn EvaluationContext) -> Result {
             $fn(a, b)
         }
         _f
@@ -33,7 +33,7 @@ macro_rules! as_binary_operator {
 
 macro_rules! as_unary_operator {
     ($fn:path) => {{
-        fn _f(a: Value, _: &dyn EvaluationContext) -> Result {
+        fn _f(a: Value, _: &mut dyn EvaluationContext) -> Result {
             $fn(a)
         }
         _f
@@ -101,7 +101,7 @@ impl<F> fmt::Debug for NamedFunction<F> {
     }
 }
 
-pub type BinaryOperator = NamedFunction<fn(Value, Value, &dyn EvaluationContext) -> Result>;
+pub type BinaryOperator = NamedFunction<fn(Value, Value, &mut dyn EvaluationContext) -> Result>;
 
 impl BinaryOperator {
     pub fn get(key: &str) -> Option<(expr_parser::operator::Fixity<Precedence>, Self)> {
@@ -133,12 +133,12 @@ impl BinaryOperator {
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum UnaryOperator {
-    Function(NamedFunction<fn(Value, &dyn EvaluationContext) -> Result>),
+    Function(NamedFunction<fn(Value, &mut dyn EvaluationContext) -> Result>),
     FieldAccess(Variable),
 }
 
 impl UnaryOperator {
-    pub fn call(&self, value: Value, ctx: &dyn EvaluationContext) -> Result {
+    pub fn call(&self, value: Value, ctx: &mut dyn EvaluationContext) -> Result {
         match self {
             Self::Function(f) => (f.function)(value, ctx),
             Self::FieldAccess(field) => value.field_access(field.clone()),

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -61,15 +61,15 @@ pub const FN_CALL_UNARY: UnaryOperator = UnaryOperator::Function(NamedFunction {
 });
 
 pub const PAREN_UNARY: UnaryOperator = UnaryOperator::Function(NamedFunction {
-    function: as_unary_operator!(Value::paren_unary),
+    function: Value::paren_unary,
     name: Variable::new_static("()"),
 });
 
 macro_rules! get_binary_builtin {
-    (match $key:ident { $($name:literal => ($fixity:expr, $fn:ident)),* $(,)? }) => {
+    (match $key:ident { $($name:literal => ($fixity:expr, $fn:expr)),* $(,)? }) => {
         match $key {
             $($name => Some(($fixity, BinaryOperator {
-                function: as_binary_operator!(Value::$fn),
+                function: $fn,
                 name: $name.into(),
             })),)*
             _ => None,
@@ -78,10 +78,10 @@ macro_rules! get_binary_builtin {
 }
 
 macro_rules! get_unary_builtin {
-    (match $key:ident { $($name:literal => ($prec:ident, $fn:ident)),* $(,)? }) => {
+    (match $key:ident { $($name:literal => ($prec:ident, $fn:expr)),* $(,)? }) => {
         match $key {
             $($name => Some((Precedence::$prec, UnaryOperator::Function(NamedFunction {
-                function: as_unary_operator!(Value::$fn),
+                function: $fn,
                 name: $name.into(),
             }))),)*
             _ => None,
@@ -108,25 +108,25 @@ impl BinaryOperator {
         use self::Precedence::*;
         use expr_parser::operator::Fixity::*;
         get_binary_builtin!(match key {
-            "==" => (Left(Comparison), eq),
-            "!=" => (Left(Comparison), ne),
-            "<" => (Left(Comparison), lt),
-            "<=" => (Left(Comparison), le),
-            ">" => (Left(Comparison), gt),
-            ">=" => (Left(Comparison), ge),
-            "max" => (Left(Comparison), max),
-            "min" => (Left(Comparison), min),
-            "+" => (Left(Additive), add),
-            "-" => (Left(Additive), sub),
-            "++" => (Left(Additive), hypot),
-            "+-+" => (Left(Additive), hypot_sub),
-            "*" => (Left(Multiplicative), mul),
-            "/" => (Left(Multiplicative), div),
-            "&" => (Left(Multiplicative), intersect),
-            "^" => (Right(Exponential), pow),
-            "<>" => (Left(Exponential), line_between),
-            ">>" => (Left(Exponential), line_vector),
-            "^^" => (Left(Exponential), line_offset),
+            "==" => (Left(Comparison), as_binary_operator!(Value::eq)),
+            "!=" => (Left(Comparison), as_binary_operator!(Value::ne)),
+            "<" => (Left(Comparison), as_binary_operator!(Value::lt)),
+            "<=" => (Left(Comparison), as_binary_operator!(Value::le)),
+            ">" => (Left(Comparison), as_binary_operator!(Value::gt)),
+            ">=" => (Left(Comparison), as_binary_operator!(Value::ge)),
+            "max" => (Left(Comparison), Value::max),
+            "min" => (Left(Comparison), Value::min),
+            "+" => (Left(Additive), Value::add),
+            "-" => (Left(Additive), Value::sub),
+            "++" => (Left(Additive), as_binary_operator!(Value::hypot)),
+            "+-+" => (Left(Additive), as_binary_operator!(Value::hypot_sub)),
+            "*" => (Left(Multiplicative), Value::mul),
+            "/" => (Left(Multiplicative), Value::div),
+            "&" => (Left(Multiplicative), Value::intersect),
+            "^" => (Right(Exponential), as_binary_operator!(Value::pow)),
+            "<>" => (Left(Exponential), Value::line_between),
+            ">>" => (Left(Exponential), Value::line_vector),
+            "^^" => (Left(Exponential), Value::line_offset),
         })
     }
 }
@@ -147,13 +147,13 @@ impl UnaryOperator {
 
     pub fn get(key: &str) -> Option<(Precedence, Self)> {
         get_unary_builtin!(match key {
-            "-" => (Multiplicative, neg),
-            "xpart" => (Multiplicative, xpart),
-            "ypart" => (Multiplicative, ypart),
-            "cos" => (Exponential, cos),
-            "sin" => (Exponential, sin),
-            "dir" => (Exponential, dir),
-            "angle" => (Exponential, angle),
+            "-" => (Multiplicative, Value::neg),
+            "xpart" => (Multiplicative, as_unary_operator!(Value::xpart)),
+            "ypart" => (Multiplicative, as_unary_operator!(Value::ypart)),
+            "cos" => (Exponential, as_unary_operator!(Value::cos)),
+            "sin" => (Exponential, as_unary_operator!(Value::sin)),
+            "dir" => (Exponential, Value::dir),
+            "angle" => (Exponential, as_unary_operator!(Value::angle)),
         })
     }
 }

--- a/src/points.rs
+++ b/src/points.rs
@@ -18,13 +18,13 @@ use crate::{
 mod line;
 mod route_corner;
 
-pub use line::{Line, LineId};
+pub use line::{LineId, LineInfo};
 use route_corner::{RouteCorners, RouteTurn};
 
 #[derive(Debug, Serialize)]
 pub struct PointCollection {
     points: Vec<PointInfo>,
-    lines: Vec<Line>,
+    lines: Vec<LineInfo>,
     #[serde(skip)]
     pairs: HashMap<(PointId, PointId), LineId>,
     routes: Vec<Route>,
@@ -103,7 +103,7 @@ impl PointCollection {
             Self::add_pair(&mut self.pairs, &mut self.points, p1, p2, line_id);
             let p1 = &self[p1];
             let p2 = &self[p2];
-            let new_line = Line::from_pair(p1.info, p2.info);
+            let new_line = LineInfo::from_pair(p1.info, p2.info);
             self.lines.push(new_line);
             line_id
         }
@@ -175,7 +175,7 @@ impl PointCollection {
         let line_id = LineId(self.lines.len());
         let origin = self[start_id].info;
         self.lines
-            .push(Line::from_origin_direction(origin, direction));
+            .push(LineInfo::from_origin_direction(origin, direction));
         line_id
     }
 
@@ -435,9 +435,9 @@ impl PointCollection {
         let reverse = reverse ^ is_start;
         let offset = segment.offset;
         let direction = if reverse {
-            -line.direction.unit()
+            -line.value.direction.unit()
         } else {
-            line.direction.unit()
+            line.value.direction.unit()
         };
         Operation {
             point: this.value,
@@ -483,23 +483,23 @@ impl IndexMut<PointId> for PointCollection {
 }
 
 impl Index<LineId> for PointCollection {
-    type Output = Line;
+    type Output = LineInfo;
 
-    fn index(&self, LineId(idx): LineId) -> &Line {
+    fn index(&self, LineId(idx): LineId) -> &LineInfo {
         &self.lines[idx]
     }
 }
 
 impl IndexMut<LineId> for PointCollection {
-    fn index_mut(&mut self, LineId(idx): LineId) -> &mut Line {
+    fn index_mut(&mut self, LineId(idx): LineId) -> &mut LineInfo {
         &mut self.lines[idx]
     }
 }
 
 impl Index<(PointId, PointId)> for PointCollection {
-    type Output = Line;
+    type Output = LineInfo;
 
-    fn index(&self, (p1, p2): (PointId, PointId)) -> &Line {
+    fn index(&self, (p1, p2): (PointId, PointId)) -> &LineInfo {
         &self[self.pairs[&(p1, p2)]]
     }
 }

--- a/src/points/line.rs
+++ b/src/points/line.rs
@@ -7,19 +7,18 @@ use std::{
 use serde::Serialize;
 
 use super::{PointId, PointInfoLite, RouteSegmentRef};
-use crate::values::{intersect, Point};
+use crate::values::{Line, Point};
 
 #[derive(Clone, Debug, Serialize)]
-pub struct Line {
-    pub direction: Point,
-    pub origin: Point,
+pub struct LineInfo {
+    pub value: Line,
     points: BTreeSet<LinePoint>,
     segments: Vec<Segment>,
 }
 
-impl Line {
+impl LineInfo {
     /// Create a new line between the two points.
-    pub fn from_pair(p1: PointInfoLite, p2: PointInfoLite) -> Line {
+    pub fn from_pair(p1: PointInfoLite, p2: PointInfoLite) -> Self {
         let mut points = BTreeSet::new();
         points.insert(LinePoint {
             distance: 0.0,
@@ -29,24 +28,25 @@ impl Line {
             distance: 1.0,
             id: p2.id,
         });
-        Line {
-            direction: p2.value - p1.value,
-            origin: p1.value,
+        Self {
+            value: Line::between(p1.value, p2.value),
             points,
             segments: Vec::new(),
         }
     }
 
     /// Create a new line with the given origin and direction.
-    pub fn from_origin_direction(origin: PointInfoLite, direction: Point) -> Line {
+    pub fn from_origin_direction(origin: PointInfoLite, direction: Point) -> Self {
         let mut points = BTreeSet::new();
         points.insert(LinePoint {
             distance: 0.0,
             id: origin.id,
         });
-        Line {
-            origin: origin.value,
-            direction,
+        Self {
+            value: Line {
+                origin: origin.value,
+                direction,
+            },
             points,
             segments: Vec::new(),
         }
@@ -58,17 +58,17 @@ impl Line {
 
     /// Calculate the distance along the line for the specified point.
     pub fn distance(&self, p: Point) -> f64 {
-        self.relative_distance(self.origin, p)
+        self.relative_distance(self.value.origin, p)
     }
 
     /// Calculate the distance between the two points along the line.
     pub fn relative_distance(&self, p1: Point, p2: Point) -> f64 {
-        (p2 - p1) * self.direction / self.direction.norm2()
+        (p2 - p1) * self.value.direction / self.value.direction.norm2()
     }
 
     /// Calculate the location of a point a given distance along the line.
     pub fn point(&self, distance: f64) -> Point {
-        distance * self.direction + self.origin
+        self.value.direction.mul_add(distance, self.value.origin)
     }
 
     /// Returns a `LinePoint` corresponding to the given `PointInfoLite`.
@@ -270,14 +270,9 @@ impl Line {
     }
 
     /// Returns the id of the point at the intersection of the two lines, if such a point exists.
-    pub fn intersect(&self, other: &Line) -> Option<PointId> {
+    pub fn intersect(&self, other: &Self) -> Option<PointId> {
         // get the distance of the intersection point along this line.
-        let distance = self.distance(intersect(
-            self.origin,
-            self.direction,
-            other.origin,
-            other.direction,
-        )?);
+        let distance = self.distance(self.value.intersect(other.value)?);
         // points to construct a range to search in. the `id` values are bogus, but we won't
         // actually be needing to do any equality comparisons.
         let start = LinePoint {

--- a/src/points/line.rs
+++ b/src/points/line.rs
@@ -79,8 +79,8 @@ impl Line {
         }
     }
 
-    pub fn add_point(&mut self, id: PointId, distance: f64) {
-        self.points.insert(LinePoint { id, distance });
+    pub fn add_point(&mut self, point: PointInfoLite) {
+        self.points.insert(self.line_point(point));
     }
 
     /// Registers the given segment with the line.

--- a/src/values.rs
+++ b/src/values.rs
@@ -791,7 +791,7 @@ pub(crate) mod tests {
         t(1), t(2), b(COMMA), u(PAREN_UNARY), t(3), t(4), b(COMMA), u(PAREN_UNARY), b("<>"),
         t(1), t(4), b(COMMA), u(PAREN_UNARY), t(3), t(2), b(COMMA), u(PAREN_UNARY), b("<>"), b("&")
     ], Point(2.0, 3.0); "intersect")]
-    // (0, 0) <> (3, 4) ^^ 5 == (4, -3) -> (7, 1)
+    // (0, 0) <> (3, 4) ^^ 5 == (-4, 3) <> (-1, 7)
     #[test_case([
         t(0), t(0), b(COMMA), u(PAREN_UNARY), t(3), t(4), b(COMMA), u(PAREN_UNARY), b("<>"),
         t(5), b("^^")

--- a/src/values.rs
+++ b/src/values.rs
@@ -653,12 +653,6 @@ impl Value {
     }
 }
 
-impl PartialEq for Value {
-    fn eq(&self, other: &Value) -> bool {
-        self.eq_bool(other).unwrap_or(false)
-    }
-}
-
 impl PartialEq<f64> for Value {
     fn eq(&self, other: &f64) -> bool {
         if let Self::Number(this) = self {

--- a/src/values.rs
+++ b/src/values.rs
@@ -244,6 +244,17 @@ impl TryFrom<Value> for (Point, PointId) {
     }
 }
 
+impl TryFrom<Value> for (Line, LineId) {
+    type Error = MathError;
+
+    fn try_from(value: Value) -> Result<(Line, LineId)> {
+        match value {
+            Value::Line(line, id) => Ok((line, id)),
+            _ => Err(MathError::Type(Type::Line, value.into())),
+        }
+    }
+}
+
 impl TryFrom<Value> for f64 {
     type Error = MathError;
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -39,7 +39,8 @@ macro_rules! numeric_fn {
     };
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Point(pub f64, pub f64);
 
 impl Point {
@@ -188,7 +189,7 @@ impl ops::Neg for UnitVector {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct Line {
     pub origin: Point,
     pub direction: Point,
@@ -653,6 +654,7 @@ impl Value {
     }
 }
 
+#[cfg(test)]
 impl PartialEq<f64> for Value {
     fn eq(&self, other: &f64) -> bool {
         if let Self::Number(this) = self {
@@ -663,6 +665,7 @@ impl PartialEq<f64> for Value {
     }
 }
 
+#[cfg(test)]
 impl PartialEq<Point> for Value {
     fn eq(&self, other: &Point) -> bool {
         if let Self::Point(this, _) = self {
@@ -673,6 +676,7 @@ impl PartialEq<Point> for Value {
     }
 }
 
+#[cfg(test)]
 impl PartialEq<&str> for Value {
     fn eq(&self, other: &&str) -> bool {
         if let Self::String(this) = self {
@@ -683,6 +687,7 @@ impl PartialEq<&str> for Value {
     }
 }
 
+#[cfg(test)]
 impl PartialEq<Line> for Value {
     fn eq(&self, other: &Line) -> bool {
         if let Self::Line(this, _) = self {

--- a/src/values.rs
+++ b/src/values.rs
@@ -392,7 +392,7 @@ impl Value {
         match (&self, rhs) {
             (&Value::Point(p1, id1), Value::Point(p2, id2)) => {
                 let line_id = ctx.point_collection().get_or_insert_line(id1, id2);
-                Ok(Value::Line(Line::between(p1, p2 - p1), line_id))
+                Ok(Value::Line(Line::between(p1, p2), line_id))
             }
             _ => Err(MathError::Type(Type::Point, self.into())),
         }
@@ -781,7 +781,10 @@ pub(crate) mod tests {
         t(1), t(4), b(COMMA), u(PAREN_UNARY), t(3), t(2), b(COMMA), u(PAREN_UNARY), b("<>"), b("&")
     ], Point(2.0, 3.0); "intersect")]
     // (0, 0) <> (3, 4) ^^ 5 == (4, -3) -> (7, 1)
-    #[test_case([t(0), t(0), b(COMMA), u(PAREN_UNARY), t(3), t(4), b(COMMA), u(PAREN_UNARY), b("<>"), t(5), b("^^")], Line::between(Point(4.0, -3.0), Point(7.0, 1.0)); "offset")]
+    #[test_case([
+        t(0), t(0), b(COMMA), u(PAREN_UNARY), t(3), t(4), b(COMMA), u(PAREN_UNARY), b("<>"),
+        t(5), b("^^")
+    ], Line::between(Point(-4.0, 3.0), Point(-1.0, 7.0)); "offset")]
     // (2, 4) min (3, 1) == (2, 1)
     #[test_case([t(2), t(4), b(COMMA), u(PAREN_UNARY), t(3), t(1), b(COMMA), u(PAREN_UNARY), b("min")], Point(2.0, 1.0); "min")]
     // "foo" + "bar" == "foobar"

--- a/src/values.rs
+++ b/src/values.rs
@@ -611,7 +611,7 @@ impl Value {
         })
     }
 
-    pub fn fn_call(self, args: Self, ctx: &dyn EvaluationContext) -> Result {
+    pub fn fn_call(self, args: Self, ctx: &mut dyn EvaluationContext) -> Result {
         match (self, args) {
             (Self::Function(f), Self::List(args)) => f.apply(&args, ctx),
             (Self::Function(f), arg) => f.apply(&[arg], ctx),
@@ -619,7 +619,7 @@ impl Value {
         }
     }
 
-    pub fn fn_call_unary(self, ctx: &dyn EvaluationContext) -> Result {
+    pub fn fn_call_unary(self, ctx: &mut dyn EvaluationContext) -> Result {
         match self {
             Self::Function(f) => f.apply(&[], ctx),
             bad => Err(MathError::Type(Type::Function, bad.into())),
@@ -702,7 +702,7 @@ pub(crate) mod tests {
     use test_case::test_case;
 
     use crate::{
-        evaluator::evaluate_expression,
+        evaluator::{evaluate_expression, Evaluator},
         expressions::tests::{b, expression_full, t, u, Expr},
         operators::{COMMA, PAREN_UNARY},
         values::Value,
@@ -789,7 +789,7 @@ pub(crate) mod tests {
     #[test_case([t("a"), t("b"), b("max")], value!(@"b"); "string max")]
     fn eval<const N: usize>(expression: [Expr; N], expected: Value) {
         assert_eq!(
-            evaluate_expression(&(), expression_full(expression)).unwrap(),
+            evaluate_expression(&mut Evaluator::default(), expression_full(expression)).unwrap(),
             expected
         );
     }


### PR DESCRIPTION
Fixes #18 

Refactors the evaluator so that:
1. All points and lines have an attached `PointId` or `LineId`
2. Any points or lines created as intermediate values in expressions are added to the `PointCollection`
3. `PointCollection` no longer tracks names of points — points are now treated just like any other variable and are stored in the evaluator.